### PR TITLE
:recycle: 반환 기본값 설정 및 예외를 줄이기 위해 조건문을 try 블럭 내부로 이동 #75

### DIFF
--- a/src/main/resources/static/global/js/api.js
+++ b/src/main/resources/static/global/js/api.js
@@ -17,22 +17,24 @@ export async function apiGetRequest( endpoint, options = {}, params = {}) {
     const mergedOptions = { ... baseOptions, ... options}
 
     let response;
-    let status;
-    let jsonResponse;
+    let status = 500;
+    let jsonResponse = {};
 
     try {
         response = await fetch(fullUrl, mergedOptions);
         status = response.status;
         jsonResponse = await response.json();
+
+        if( !response.ok && isAuthException(status, jsonResponse.errorCode)) {
+            handleAuthException(status);
+            return;
+        }
     } catch (error){
         console.error('API Request Error :' , error);
         renderCommonAlertMessage('네트워트 연결 오류', defaultErrorMessage);
+        jsonResponse = {}; // 안전하게 기본 값 재설정
     }
 
-    if( !response.ok && isAuthException(status, jsonResponse.errorCode)) {
-        handleAuthException(status);
-        return;
-    }
 
     return {status : status, data : jsonResponse?.data ?? jsonResponse};
 }
@@ -53,21 +55,21 @@ export async function apiPostRequest( endpoint, options = {}, body) {
     const mergedOptions = { ... baseOptions, ... options}
 
     let response;
-    let status;
-    let jsonResponse;
+    let status = 500;
+    let jsonResponse = {};
 
     try {
         response = await fetch(API_URL + endpoint, mergedOptions);
         status = response.status;
         jsonResponse = await response.json();
+
+        if( !response.ok && isAuthException(status, jsonResponse.errorCode)) {
+            handleAuthException(status);
+        }
     } catch (error){
         console.error('API Request Error :' , error);
         renderCommonAlertMessage("네트워크 연결 오류", defaultErrorMessage);
-    }
-
-    if( !response.ok && isAuthException(status, jsonResponse.errorCode)) {
-        handleAuthException(status);
-        return;
+        jsonResponse = {}; // 안전하게 기본 값 재설정
     }
 
     return {status : status, data : jsonResponse?.data ?? jsonResponse};


### PR DESCRIPTION
### 📌 이슈
> ex) #이슈번호

### ✅ 작업내용
- 현재 api 호출 공통함수의 반환 구조는, 예외 반환 시 상태코드를 반환해주지 않기에 해당 함수 호출부에서 올바른 처리를 기대하기가 어려움
- 예외 반환 시 format을 일관되게 처리 하도록 로직 개선
