### PR TITLE
[홈] 대결 진행 불가능 이슈 해결 #197

### DIFF
--- a/src/main/resources/static/home/js/home.js
+++ b/src/main/resources/static/home/js/home.js
@@ -47,9 +47,9 @@ function addTopicCardEvents(){
         const btnTopicStats = event.target.closest('.btn-topic-stats');
         if (btnTopicStats) {
             const topicId = topicCard.dataset.id;
-
             window.open(`/statistics/topic/${topicId}`, '_blank'); // 통계페이지 이동(새 탭 열기)
         } else if (topicCard) {
+            const topicId = topicCard.dataset.id;
             await openTournamentSelectDialog(topicId);
         }
     });


### PR DESCRIPTION
### 📌 이슈
> #197

### ✅ 작업내용

- 대결 진행을 위해 대결주제 상호작용 시 토너먼트 선택 다이얼로그가 등장하지 않는 이슈 해결


- 원인
   - [대결진행 페이지 새 탭에서 진행](https://github.com/douchman/VsApp/issues/177) 기능 추가 이후, 참조하는 대결주제의 식별자를 확인 할 수 없음

- 해결
   - 누락된 대결주제 식별자 참조 추가
