### PR TITLE
[엔트리 대결 진행] 새로고침 관련 이슈 해결 #198

### DIFF
--- a/src/main/resources/static/topic/play/js/topic-play.js
+++ b/src/main/resources/static/topic/play/js/topic-play.js
@@ -2,12 +2,10 @@ import {topic, playRecord} from "./const.js";
 import {showToastMessage} from "../../../global/popup/js/common-toast-message.js";
 import {apiGetRequest} from "../../../global/js/api.js";
 import {loadEntryMatchInfo} from "./entry-match.js";
-import {flushPlayRecordIdsFromLocalStorage} from "../../../global/js/vstopic-localstorage.js";
 import {loadYoutubeIframeAPI, onYouTubeIframeApiReady} from "../../../global/js/youtube-iframe-api.js";
 
 document.addEventListener('DOMContentLoaded', async () => {
 
-    addPlayRecordIdFlushEventOnUnload();
     const topicSuccess  = await saveTopicInfo(); // 대결주제 식별자 변수화
     const playRecordSuccess = savePlayRecordInfo(); // 대결진행기록 식별자 변수화
 
@@ -89,18 +87,4 @@ function handleSetTopicFailed(){
     setTimeout(()=> {
         location.href = '/';
     }, 2500);
-}
-
-/**
- * 새로고침을 제외한 페이지 이탈 시 로컬스토리지 비우기
- */
-function addPlayRecordIdFlushEventOnUnload(){
-    window.addEventListener('beforeunload', () => {
-        //event.preventDefault();
-        const navigationType = performance.getEntries()[0].type;
-        const isReload = navigationType === 'reload';
-        if(!isReload){
-            flushPlayRecordIdsFromLocalStorage();
-        }
-    });
 }


### PR DESCRIPTION
### 📌 이슈
> #198

### ✅ 작업내용
- 엔트리 대결 진행은 [중복 처리] 및 [직접 진입] 또는 [의도하지 않은 접근] 을 방지하기 위해, localStorage 에 저장된 playRecord 식별자 비우도록 되어있음
- 위 과정은 안전한 처리를 위해 마련되었으나, 새로고침 시 저장된 storage 가 비워지면서, 다시 진행 할 수 없는 이슈를 해결하기 위해 [[로컬스토리지 저장값 초기화 문제 완화]](https://github.com/douchman/VsApp/issues/113) 에서 처리한 기록이 있음
- 허나 의도한 대로 동작하지 않고, 새로고침 시에도 localStorage 가 비워지는 이슈를 확인

- 원인
   - 네비게이션 타입이 항상 reload 임을 신뢰 할 수 없기에 이런 현상이 발생하는 것으로 '예상' 됨


- 해결 (임시)
   - 페이지 이탈 시 로컬스토리지 비우기 처리 제거
