### PR TITLE
[엔트리 대결 진행] 가로스크롤 이슈 해결 #203

### DIFF
--- a/src/main/resources/static/topic/play/css/match-stage.css
+++ b/src/main/resources/static/topic/play/css/match-stage.css
@@ -7,6 +7,7 @@
     height: calc(100% - var(--topic-header-height));
     box-sizing: border-box;
     padding: 20px 0 60px 0;
+    overflow-x: hidden;
 }
 
 .match-stage:after{


### PR DESCRIPTION
### 📌 이슈
>#203

### ✅ 작업내용
- 엔트리 대결 진행 중, 좌측 엔트리가 승리하여 패배한 엔트리가 우측으로 밀려나는 애니메이션이 진행 되면 match-stage 에 가로 스크롤이 생기는 이슈 확인

- 원인
   - 패배한 엔트리를 단순히 transform 하여 이동시키는데, 가로스크롤 관련 스타일 처리가 되어있지 않음  match-stage 의 영역밖으로 나간 요소를 보여주기 위해 브라우저가 자동으로 스크롤을 생성하는 것이 원인으로 추정

- 해결 방안 
   -  match-stage 에 overflow-x : hidden 스타일 추가
