### PR TITLE
[대결 진행] 이미 완료된 대결 셋업 시 match-stage 상태 변경 추가 #404

### DIFF
--- a/src/main/resources/static/topic/play/js/entry-match.js
+++ b/src/main/resources/static/topic/play/js/entry-match.js
@@ -23,7 +23,8 @@ export async function loadEntryMatchInfo() {
         if( PlayStatus.IN_PROGRESS === playStatus){ // 진행중인 대결
             renderEntriesAndAddEvents(entryMatch);
         } else { // 완료된 대결
-            const winnerEntryId = currentEntryMatchResult.winnerEntryId
+            const winnerEntryId = currentEntryMatchResult.winnerEntryId;
+            toggleMatchStageStatus(true);
             setupCompletedEntryMatch(winnerEntryId, entryMatch);
         }
 


### PR DESCRIPTION
### 📌 이슈
> #404

### ✅ 작업내용
- 완료된 대결 setup 시 match-stage 에 경기 진행 상태 갱신
