### PR TITLE
[인증 요구 페이지] 회원 전용 페이지 이동 로직 수정 #461

### DIFF
--- a/src/main/java/com/buck/vstournament/controller/PageController.java
+++ b/src/main/java/com/buck/vstournament/controller/PageController.java
@@ -1,5 +1,6 @@
 package com.buck.vstournament.controller;
 
+import com.buck.vstournament.controller.support.AuthGuard;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,16 +31,19 @@ public class PageController {
 
     @GetMapping("topic/create")
     public String createTopic(){
+        AuthGuard.requireAuth();
         return "topic/edit/create/topic-create";
     }
 
     @GetMapping("topic/my")
     public String myTopics(){
+        AuthGuard.requireAuth();
         return "topic/my/my-topic";
     }
 
     @GetMapping("topic/modify/{topicId}")
     public String modifyTopic(@PathVariable String topicId){
+        AuthGuard.requireAuth();
         return "topic/edit/modify/topic-modify";
     }
 

--- a/src/main/java/com/buck/vstournament/controller/support/AuthExceptionHandler.java
+++ b/src/main/java/com/buck/vstournament/controller/support/AuthExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.buck.vstournament.controller.support;
+
+import com.buck.vstournament.controller.support.exception.UnAuthorizedException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class AuthExceptionHandler {
+    private static final String LOGIN_PAGE_REDIRECT = "redirect:/login";
+
+    @ExceptionHandler(UnAuthorizedException.class)
+    public String handleUnAuthorizedException() {
+        return LOGIN_PAGE_REDIRECT;
+    }
+}

--- a/src/main/java/com/buck/vstournament/controller/support/AuthGuard.java
+++ b/src/main/java/com/buck/vstournament/controller/support/AuthGuard.java
@@ -1,0 +1,34 @@
+package com.buck.vstournament.controller.support;
+
+import com.buck.vstournament.controller.support.exception.UnAuthorizedException;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+public class AuthGuard {
+
+    private static final String TOKEN_COOKIE_NAME = "token";
+
+    private AuthGuard() {}
+
+    public static void requireAuth() {
+        HttpServletRequest request = getCurrentRequest();
+
+        boolean hasToken = Optional.ofNullable(request.getCookies()).stream().flatMap(Arrays::stream)
+                .anyMatch( cookie -> TOKEN_COOKIE_NAME.equals(cookie.getName()));
+
+        if(!hasToken) {
+            throw new UnAuthorizedException();
+        }
+
+    }
+
+    private static HttpServletRequest getCurrentRequest() {
+        return ((ServletRequestAttributes)
+                RequestContextHolder.currentRequestAttributes())
+                .getRequest();
+    }
+}

--- a/src/main/java/com/buck/vstournament/controller/support/exception/UnAuthorizedException.java
+++ b/src/main/java/com/buck/vstournament/controller/support/exception/UnAuthorizedException.java
@@ -1,0 +1,4 @@
+package com.buck.vstournament.controller.support.exception;
+
+public class UnAuthorizedException extends RuntimeException {
+}


### PR DESCRIPTION
### 📌 이슈
> #461

### ✅ 작업내용
- 로그인 여부 처기
   - 클라이언트 사이드에서는 토큰 관련 검증 로직을 다루지 않음 -> 단순 쿠키 내 token 존재 여부만 검사
   - 여부 검사는 JS 에서 불가능하기에, Java 에서 처리하도록 구현
   - 토큰 존재 여부 관련 예외와 처리 핸들러를 추가하고, 인증 여부(토큰 존재여부)  /support/Guard.java 추가
   - 인증이 필요한 페이지 매핑에서만 guard 호출
