### PR TITLE
[대결주제 편집] 엔트리 미디어 용량 제한 수정 #462

### DIFF
--- a/src/main/resources/static/topic/edit/core/js/entry-section/entry-media-validate.js
+++ b/src/main/resources/static/topic/edit/core/js/entry-section/entry-media-validate.js
@@ -6,7 +6,7 @@ let hasShownUploadSizeWarning = false;
 
 const MAX_IMAGE_SIZE_MB = 2; // 업로드 가능 비디오 용량 2MB
 const MAX_VIDEO_SIZE_MB = 8; // 업로드 가능 비디오 용량 3MB
-const ALERT_TOTAL_UPLOAD_MB = 40; // 업로드 경고 요량 기준 40MB
+const ALERT_TOTAL_UPLOAD_MB = 50; // 업로드 경고 요량 기준 40MB
 const MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024;
 const MAX_VIDEO_SIZE_BYTES = MAX_VIDEO_SIZE_MB * 1024 * 1024;
 const ALERT_TOTAL_UPLOAD_BYTES = ALERT_TOTAL_UPLOAD_MB * 1024 * 1024;

--- a/src/main/resources/static/topic/edit/core/js/entry-section/entry-media-validate.js
+++ b/src/main/resources/static/topic/edit/core/js/entry-section/entry-media-validate.js
@@ -5,7 +5,7 @@ import {stagedEntryMedia} from "../staged-entry-media.js";
 let hasShownUploadSizeWarning = false;
 
 const MAX_IMAGE_SIZE_MB = 2; // 업로드 가능 비디오 용량 2MB
-const MAX_VIDEO_SIZE_MB = 3; // 업로드 가능 비디오 용량 3MB
+const MAX_VIDEO_SIZE_MB = 8; // 업로드 가능 비디오 용량 3MB
 const ALERT_TOTAL_UPLOAD_MB = 40; // 업로드 경고 요량 기준 40MB
 const MAX_IMAGE_SIZE_BYTES = MAX_IMAGE_SIZE_MB * 1024 * 1024;
 const MAX_VIDEO_SIZE_BYTES = MAX_VIDEO_SIZE_MB * 1024 * 1024;


### PR DESCRIPTION
### 📌 이슈
> #462

### ✅ 작업내용
- 비디오 업로드 제한 기존 용량(3MB) 이 다소 작다고 판단
   - 13초 내외의 클립으로 예상되며, 이는 용량이 10MB 내외 
- 더 다양한 미디어를 추가할 수 있도록 업로드 가능한 개별 비디오 유형 미디어 용량 제한을 상향 조정( 3MB -> 8MB)
- 개별 미디어 용량이 늘어났기에 경고 기준 용량도 소폭 상향 조정
