### PR TITLE
[대결주제 편집] 대결주제 수정 완료 후 이동페이지 변경 #488

### DIFF
--- a/src/main/resources/static/topic/edit/modify/js/modify-main.js
+++ b/src/main/resources/static/topic/edit/modify/js/modify-main.js
@@ -53,7 +53,7 @@ function addBottomBtnGroupEvents(){
                 content : '대결주제 수정이 완료되었습니다'
             });
             setTimeout(() =>{
-                location.href = '/';
+                location.href = '/topic/my';
             }, 2000);
         } else{
             toggleBtnSaveBlock(false);


### PR DESCRIPTION
### 📌 이슈
> #488

### ✅ 작업내용
- 대결주제 수정 완료 시 기본 대결주제 페이지가 아닌 내 대결주제 페이지로 이동하도록 변경
